### PR TITLE
Update gitignore for Ruff cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.ruff_cache/
 nosetests.xml
 coverage.xml
 *,cover


### PR DESCRIPTION
## Summary
- ignore `.ruff_cache/` folder

## Testing
- `pytest -q`
- `ruff check .`
