### PR TITLE
Add cross-platform run wrapper

### DIFF
--- a/run
+++ b/run
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+"""Platform-aware wrapper to run project automation scripts."""
+import os
+import platform
+import subprocess
+import sys
+
+def main() -> int:
+    repo_root = os.path.dirname(os.path.abspath(__file__))
+    if platform.system().lower().startswith("windows"):
+        script = os.path.join(repo_root, "scripts", "run.ps1")
+        cmd = ["powershell", "-ExecutionPolicy", "Bypass", "-File", script]
+    else:
+        script = os.path.join(repo_root, "scripts", "run.sh")
+        cmd = ["bash", script]
+    cmd.extend(sys.argv[1:])
+    return subprocess.call(cmd)
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add executable `run` helper that chooses the platform-specific script

## Testing
- `ruff check .`
- `pytest`
