### PR TITLE
Fix env API functions

### DIFF
--- a/examples/random-random-walk.py
+++ b/examples/random-random-walk.py
@@ -11,7 +11,7 @@ num_steps_per_episode = 200
 
 collected_rewards = []
 for i in range(num_episodes):
-    s = env.reset()
+    s, _ = env.reset()
     print ("starting new episode")
     env.render()
     print ("started")

--- a/gym_random_walk/envs/random_walk_env.py
+++ b/gym_random_walk/envs/random_walk_env.py
@@ -3,33 +3,44 @@ from gym import spaces
 import numpy as np
 
 class RandomWalkEnv(gym.Env):
-  metadata = {'render.modes': ['human']}
+    """Simple random walk environment."""
 
-  def __init__(self):
-    self.action_space = spaces.Discrete(2)
-    self.size = 6
-    #print("init")
-  def _step(self, action):
-    #print("step")
-    reward = 0
-    done = False
-    if (action == 0):
-       self.state -= 1
-    if (action == 1):
-        self.state += 1
-    if (self.state >= self.size):
-        reward = 1
-        done = True
-    if (self.state <= 0):
-        done = True
-    return np.array(self.state), reward, done, {}
-  def _reset(self):
-    #print("reset")
-    print("#self.size:",self.size)
-    self.state =  np.random.randint(1,self.size-1)
-    print("starting: ", self.state)
-  def _render(self, mode='human', close=False):
-    if close:
-        return
-    #print("render")
-    print("current state: ",self.state)
+    metadata = {"render.modes": ["human"]}
+
+    def __init__(self, size: int = 6, debug: bool = False) -> None:
+        super().__init__()
+        self.size = size
+        self.debug = debug
+        self.action_space = spaces.Discrete(2)
+        self.observation_space = spaces.Discrete(self.size + 1)
+        self.state = None
+
+    def step(self, action):
+        reward = 0
+        done = False
+        if action == 0:
+            self.state -= 1
+        if action == 1:
+            self.state += 1
+        if self.state >= self.size:
+            reward = 1
+            done = True
+        if self.state <= 0:
+            done = True
+        if self.debug:
+            print("current state:", self.state)
+        return np.array(self.state), reward, done, {}
+
+    def reset(self, *, seed: int | None = None, options: dict | None = None):
+        super().reset(seed=seed)
+        if self.debug:
+            print("#self.size:", self.size)
+        self.state = np.random.randint(1, self.size - 1)
+        if self.debug:
+            print("starting:", self.state)
+        return np.array(self.state), {}
+
+    def render(self, mode: str = "human"):
+        if not self.debug:
+            return
+        print("current state:", self.state)


### PR DESCRIPTION
## Summary
- rename `_step`, `_reset`, `_render` to `step`, `reset`, `render`
- add debug flag and observation space
- ensure `reset` returns observation and info
- update example to unpack `reset` return

## Testing
- `ruff check .`
- `pytest -q`
