### PR TITLE
Remove leftover extrahard env comment

### DIFF
--- a/gym_random_walk/__init__.py
+++ b/gym_random_walk/__init__.py
@@ -4,7 +4,3 @@ register(
     id='random_walk-v0',
     entry_point='gym_random_walk.envs:RandomWalkEnv',
 )
-#register(
-#    id='foo-extrahard-v0',
-#    entry_point='gym_foo.envs:FooExtraHardEnv',
-#)


### PR DESCRIPTION
## Summary
- delete stray FooExtraHardEnv references in the package init

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_682936c8a62c8332891c4d39bd91dfb7