### PR TITLE
Migrate from OpenAI Gym to Gymnasium

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a minimal custom environment for OpenAI Gym implementing a one-dimensional random walk. The environment features configurable state space with terminal states at both ends, binary actions (left/right), and simple reward structure.
+This is a minimal custom environment for Gymnasium (formerly OpenAI Gym) implementing a one-dimensional random walk. The environment features configurable state space with terminal states at both ends, binary actions (left/right), and simple reward structure.
 
 ## Requirements
 
 - Python 3.8-3.11 (recommended: 3.11, tested with 3.8, 3.9, 3.10, 3.11)
-- Dependencies: gym==0.7.4, numpy==1.22.0, pytest==7.4.4
+- Dependencies: gymnasium==1.0.0, numpy==1.22.0, pytest==7.4.4
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gym-random-walk
 
-A minimal example of a custom environment for [OpenAI Gym](https://github.com/openai/gym).
+A minimal example of a custom environment for [Gymnasium](https://github.com/Farama-Foundation/Gymnasium) (formerly OpenAI Gym).
 
 This environment implements a one-dimensional random walk. The states are `0, 1, ..., 6` with `0` and `6` being terminal. The starting state is chosen uniformly from `1` through `5`.
 
@@ -9,11 +9,11 @@ You can move left or right by selecting a discrete action. Reaching the rightmos
 ## Requirements
 
 - **Python 3.8-3.11** (tested with 3.8, 3.9, 3.10, 3.11)
-- **OpenAI Gym 0.7.4** (original version from 2017)
+- **Gymnasium 1.0.0** (modern fork of OpenAI Gym)
 - **NumPy 1.22.0** (minimum version to address security vulnerabilities)
 - **pytest 7.4.4** (for running tests)
 
-This project uses older versions of dependencies to maintain compatibility with the original codebase from 2017. The pinned versions are specified in `requirements.txt`.
+This project has been updated to use Gymnasium, the maintained fork of OpenAI Gym. The pinned versions are specified in `requirements.txt`.
 
 ## Installation
 
@@ -41,14 +41,15 @@ bash scripts/setup.sh
 ## Example
 
 ```python
-import gym
+import gymnasium as gym
 import gym_random_walk
 
 env = gym.make("random_walk-v0")
-state = env.reset()
+state, info = env.reset()
 done = False
 while not done:
-    state, reward, done, _ = env.step(env.action_space.sample())
+    state, reward, terminated, truncated, info = env.step(env.action_space.sample())
+    done = terminated or truncated
 ```
 
 ## Development

--- a/examples/random-random-walk.py
+++ b/examples/random-random-walk.py
@@ -1,31 +1,32 @@
-import gym
+import gymnasium as gym
 import numpy as np
 import gym_random_walk
 
 _ = gym_random_walk  # register env
 
-env = gym.make('random_walk-v0')
+env = gym.make('random_walk-v0', render_mode='human')
 
 num_episodes = 20
 num_steps_per_episode = 200
 
 collected_rewards = []
 for i in range(num_episodes):
-    s = env.reset()
-    print ("starting new episode")
+    s, _ = env.reset()
+    print("starting new episode")
     env.render()
-    print ("started")
+    print("started")
     total_reward = 0
     done = False
     for j in range(num_steps_per_episode):
         a = np.random.randint(env.action_space.n)
-        s1, reward, done, _ = env.step(a)
+        s1, reward, terminated, truncated, _ = env.step(a)
+        done = terminated or truncated
         env.render()
         total_reward += reward
         s = s1
         if done:
             break
     collected_rewards.append(total_reward)
-    print ("total reward ", total_reward, " after episode: ", j)
-print ("average score: ", sum(collected_rewards) / num_episodes)
+    print("total reward ", total_reward, " after episode: ", j)
+print("average score: ", sum(collected_rewards) / num_episodes)
 print("#########")

--- a/gym_random_walk/__init__.py
+++ b/gym_random_walk/__init__.py
@@ -1,4 +1,4 @@
-from gym.envs.registration import register
+from gymnasium.envs.registration import register
 from ._version import __version__
 
 register(

--- a/gym_random_walk/_version.py
+++ b/gym_random_walk/_version.py
@@ -1,11 +1,11 @@
 """Version information for gym-random-walk package."""
 
-__version__ = '0.1.1'
+__version__ = '1.0.0'
 
 # Dependency versions
 PYTHON_VERSION = '3.11'
 NUMPY_VERSION = '1.22.0'
-GYM_VERSION = '0.7.4'
+GYMNASIUM_VERSION = '1.0.0'
 PYTEST_VERSION = '7.4.4'
 
 # Version requirements for setup.py

--- a/gym_random_walk/_version.py
+++ b/gym_random_walk/_version.py
@@ -1,6 +1,6 @@
 """Version information for gym-random-walk package."""
 
-__version__ = '1.0.0'
+__version__ = '0.2.0'
 
 # Dependency versions
 PYTHON_VERSION = '3.11'

--- a/gym_random_walk/envs/random_walk_env.py
+++ b/gym_random_walk/envs/random_walk_env.py
@@ -1,50 +1,65 @@
-import gym
-from gym import spaces
+import gymnasium as gym
+from gymnasium import spaces
 import numpy as np
-from typing import Union, Optional, Dict
+from typing import Optional, Dict, Tuple, Any
 
 class RandomWalkEnv(gym.Env):
     """Simple random walk environment."""
 
-    metadata = {"render.modes": ["human"]}
+    metadata = {"render_modes": ["human"]}
 
-    def __init__(self, size=6, debug=False):
+    def __init__(self, size=6, debug=False, render_mode=None):
         super().__init__()
         self.size = size
         self.debug = debug
+        self.render_mode = render_mode
         self.action_space = spaces.Discrete(2)
         self.observation_space = spaces.Discrete(self.size + 1)
         self.state = None
 
-    def step(self, action):
+    def step(self, action) -> Tuple[np.ndarray, float, bool, bool, Dict[str, Any]]:
         reward = 0
-        done = False
+        terminated = False
+        truncated = False
+        
         if action == 0:
             self.state -= 1
         if action == 1:
             self.state += 1
+            
         if self.state >= self.size:
             reward = 1
-            done = True
+            terminated = True
         if self.state <= 0:
-            done = True
+            terminated = True
+            
         if self.debug:
             print("current state:", self.state)
-        # Return the old Gym API format (3 values)
-        return np.array(self.state), reward, done, {}
+            
+        # Render if mode is set
+        if self.render_mode == "human":
+            self.render()
+            
+        # Return the new Gymnasium API format (5 values)
+        return np.array(self.state), reward, terminated, truncated, {}
 
-    def reset(self, seed=None, options=None):
-        # For gym 0.7.4 compatibility, reset doesn't call super().reset()
+    def reset(self, seed: Optional[int] = None, options: Optional[Dict] = None) -> Tuple[np.ndarray, Dict]:
+        # Properly handle seeding in Gymnasium
+        super().reset(seed=seed)
+        
         if self.debug:
             print("#self.size:", self.size)
-        self.state = np.random.randint(1, self.size)
+            
+        # Use the environment's random number generator
+        self.state = self.np_random.integers(1, self.size)
+        
         if self.debug:
             print("starting:", self.state)
-        return np.array(self.state)
+            
+        # Return observation and info dict
+        return np.array(self.state), {}
 
-    def render(self, mode="human", close=False):
-        if close:
-            return
+    def render(self):
         if not self.debug:
             return
         print("current state:", self.state)

--- a/gym_random_walk/envs/random_walk_env.py
+++ b/gym_random_walk/envs/random_walk_env.py
@@ -17,7 +17,7 @@ class RandomWalkEnv(gym.Env):
         self.observation_space = spaces.Discrete(self.size + 1)
         self.state = None
 
-    def step(self, action) -> Tuple[np.ndarray, float, bool, bool, Dict[str, Any]]:
+    def step(self, action) -> Tuple[int, float, bool, bool, Dict[str, Any]]:
         reward = 0
         terminated = False
         truncated = False
@@ -41,9 +41,9 @@ class RandomWalkEnv(gym.Env):
             self.render()
             
         # Return the new Gymnasium API format (5 values)
-        return np.array(self.state), reward, terminated, truncated, {}
+        return self.state, reward, terminated, truncated, {}
 
-    def reset(self, seed: Optional[int] = None, options: Optional[Dict] = None) -> Tuple[np.ndarray, Dict]:
+    def reset(self, seed: Optional[int] = None, options: Optional[Dict] = None) -> Tuple[int, Dict]:
         # Properly handle seeding in Gymnasium
         super().reset(seed=seed)
         
@@ -57,7 +57,7 @@ class RandomWalkEnv(gym.Env):
             print("starting:", self.state)
             
         # Return observation and info dict
-        return np.array(self.state), {}
+        return self.state, {}
 
     def render(self):
         if not self.debug:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-gym==0.7.4
+gymnasium==1.0.0
 pytest==7.4.4
 numpy==1.22.0

--- a/scripts/update_requirements.py
+++ b/scripts/update_requirements.py
@@ -6,10 +6,10 @@ import os
 
 # Add gym_random_walk directory to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'gym_random_walk'))
-from _version import GYM_VERSION, PYTEST_VERSION, NUMPY_VERSION
+from _version import GYMNASIUM_VERSION, PYTEST_VERSION, NUMPY_VERSION
 
 # Generate requirements.txt content
-requirements = f"""gym=={GYM_VERSION}
+requirements = f"""gymnasium=={GYMNASIUM_VERSION}
 pytest=={PYTEST_VERSION}
 numpy=={NUMPY_VERSION}
 """

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,12 @@ import sys
 
 # Add the package directory to sys.path so we can import _version
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'gym_random_walk'))
-from _version import __version__, PYTHON_REQUIRES, GYM_VERSION, NUMPY_VERSION
+from _version import __version__, PYTHON_REQUIRES, GYMNASIUM_VERSION, NUMPY_VERSION
 
 setup(name='gym_random_walk',
       version=__version__,
       install_requires=[
-          f'gym=={GYM_VERSION}',
+          f'gymnasium=={GYMNASIUM_VERSION}',
           f'numpy=={NUMPY_VERSION}',
       ],
       python_requires=PYTHON_REQUIRES,

--- a/tests/test_random_walk.py
+++ b/tests/test_random_walk.py
@@ -1,4 +1,4 @@
-import gym
+import gymnasium as gym
 import gym_random_walk
 
 _ = gym_random_walk  # ensure environment is registered
@@ -6,15 +6,16 @@ _ = gym_random_walk  # ensure environment is registered
 
 def test_reset_start_state():
     env = gym.make("random_walk-v0")
-    state = env.reset()
+    state, _ = env.reset()
     assert 1 <= state <= 5
 
 
 def test_episode_terminates_at_terminal_state():
     env = gym.make("random_walk-v0")
-    state = env.reset()
+    state, _ = env.reset()
     for _ in range(100):
-        state, _, done, _ = env.step(env.action_space.sample())
+        state, _, terminated, truncated, _ = env.step(env.action_space.sample())
+        done = terminated or truncated
         if done:
             break
     assert done, "episode did not terminate in 100 steps"

--- a/tests/test_random_walk_env.py
+++ b/tests/test_random_walk_env.py
@@ -1,19 +1,19 @@
 import numpy as np
 import pytest
 
-gym = pytest.importorskip("gym")
+gym = pytest.importorskip("gymnasium")
 import gym_random_walk
 
 
 def test_random_walk_step():
     env = gym.make("random_walk-v0")
     try:
-        obs = env.reset()
+        obs, _ = env.reset()
         state = getattr(env, "state", None)
         assert state is not None
         assert 1 <= state <= env.size - 1
 
-        obs, reward, done, _ = env.step(1)
+        obs, reward, terminated, truncated, _ = env.step(1)
         obs_val = int(obs)
         assert 0 <= obs_val <= env.size
         assert reward in (0, 1)

--- a/tests/test_random_walk_env.py
+++ b/tests/test_random_walk_env.py
@@ -9,13 +9,15 @@ def test_random_walk_step():
     env = gym.make("random_walk-v0")
     try:
         obs, _ = env.reset()
-        state = getattr(env, "state", None)
+        # Access the unwrapped environment to get internal state
+        unwrapped_env = env.unwrapped
+        state = getattr(unwrapped_env, "state", None)
         assert state is not None
-        assert 1 <= state <= env.size - 1
+        assert 1 <= state <= unwrapped_env.size - 1
 
         obs, reward, terminated, truncated, _ = env.step(1)
         obs_val = int(obs)
-        assert 0 <= obs_val <= env.size
+        assert 0 <= obs_val <= unwrapped_env.size
         assert reward in (0, 1)
         # done could be True or False depending on the initial state
     finally:

--- a/tests/test_readme_example.py
+++ b/tests/test_readme_example.py
@@ -1,5 +1,5 @@
 """Test the example code from README.md to ensure it works correctly."""
-import gym
+import gymnasium as gym
 import gym_random_walk
 
 _ = gym_random_walk  # ensure environment is registered
@@ -8,7 +8,7 @@ _ = gym_random_walk  # ensure environment is registered
 def test_readme_example_runs():
     """Test that the example code from README.md runs without errors."""
     env = gym.make("random_walk-v0")
-    state = env.reset()
+    state, _ = env.reset()
     done = False
     
     # Run for a maximum of 100 steps to ensure test doesn't run forever
@@ -16,7 +16,8 @@ def test_readme_example_runs():
     max_steps = 100
     
     while not done and steps < max_steps:
-        state, reward, done, _ = env.step(env.action_space.sample())
+        state, reward, terminated, truncated, _ = env.step(env.action_space.sample())
+        done = terminated or truncated
         steps += 1
         
         # Verify state is within valid range
@@ -41,13 +42,14 @@ def test_readme_example_multiple_episodes():
     num_episodes = 10
     
     for _ in range(num_episodes):
-        state = env.reset()
+        state, _ = env.reset()
         done = False
         episode_reward = 0
         steps = 0
         
         while not done and steps < 100:
-            state, reward, done, _ = env.step(env.action_space.sample())
+            state, reward, terminated, truncated, _ = env.step(env.action_space.sample())
+            done = terminated or truncated
             episode_reward += reward
             steps += 1
         

--- a/tests/test_readme_example.py
+++ b/tests/test_readme_example.py
@@ -21,11 +21,11 @@ def test_readme_example_runs():
         steps += 1
         
         # Verify state is within valid range
-        assert 0 <= state <= env.size
+        assert 0 <= state <= env.unwrapped.size
         
         # Verify reward is correct based on terminal state
         if done:
-            if state == env.size:
+            if state == env.unwrapped.size:
                 assert reward == 1
             elif state == 0:
                 assert reward == 0


### PR DESCRIPTION
## Summary
This PR migrates the project from the deprecated OpenAI Gym 0.7.4 to Gymnasium 1.0.0, the actively maintained fork.

## Changes
- **API Migration**:
  - `step()` now returns 5 values: `(obs, reward, terminated, truncated, info)`
  - `reset()` returns tuple: `(obs, info)`
  - Proper seeding with `super().reset(seed=seed)`
  - Use `self.np_random` for reproducible randomness
  
- **Import Updates**:
  - All `import gym` → `import gymnasium as gym`
  - Updated registration imports
  
- **Rendering Changes**:
  - `render_mode` set at environment initialization
  - Removed deprecated `mode` and `close` parameters
  
- **Dependencies**:
  - Updated from `gym==0.7.4` to `gymnasium==1.0.0`
  - Kept numpy at 1.22.0 for compatibility
  
- **Version Bump**:
  - Bumped to 0.2.0 to indicate breaking changes

## Breaking Changes
Users will need to update their code to handle the new API:
- `reset()` now returns a tuple
- `step()` returns 5 values instead of 4
- Import statements need to change

## Testing
All tests have been updated for the new API. CI will verify compatibility across Python 3.8-3.11.

Closes #28