### PR TITLE
Update to Python 3.12 as default and numpy 1.26.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
       fail-fast: false
     
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,8 @@ This is a minimal custom environment for Gymnasium (formerly OpenAI Gym) impleme
 
 ## Requirements
 
-- Python 3.8-3.11 (recommended: 3.11, tested with 3.8, 3.9, 3.10, 3.11)
-- Dependencies: gymnasium==1.0.0, numpy==1.22.0, pytest==7.4.4
+- Python 3.9-3.12 (recommended: 3.11, tested with 3.9, 3.10, 3.11, 3.12)
+- Dependencies: gymnasium==1.0.0, numpy==1.26.0, pytest==7.4.4
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,14 +8,14 @@ This is a minimal custom environment for Gymnasium (formerly OpenAI Gym) impleme
 
 ## Requirements
 
-- Python 3.9-3.12 (recommended: 3.11, tested with 3.9, 3.10, 3.11, 3.12)
-- Dependencies: gymnasium==1.0.0, numpy==1.26.0, pytest==7.4.4
+- Python 3.9-3.12 (recommended: 3.12, tested with 3.9, 3.10, 3.11, 3.12)
+- Dependencies: gymnasium==1.0.0, numpy==1.26.4, pytest==7.4.4
 
 ## Commands
 
 ### Setup and Installation
 ```bash
-# Run the setup script (installs Python 3.11 if needed on Ubuntu)
+# Run the setup script (installs Python 3.12 if needed on Ubuntu)
 bash scripts/setup.sh
 
 # Or manually:

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ You can move left or right by selecting a discrete action. Reaching the rightmos
 
 ## Requirements
 
-- **Python 3.9-3.12** (tested with 3.9, 3.10, 3.11, 3.12)
+- **Python 3.9-3.12** (recommended: 3.12, tested with 3.9, 3.10, 3.11, 3.12)
 - **Gymnasium 1.0.0** (modern fork of OpenAI Gym)
-- **NumPy 1.26.0** (minimum version for Python 3.12 support)
+- **NumPy 1.26.4** (minimum version for Python 3.12 support)
 - **pytest 7.4.4** (for running tests)
 
 This project has been updated to use Gymnasium, the maintained fork of OpenAI Gym. The pinned versions are specified in `requirements.txt`.
@@ -19,7 +19,7 @@ This project has been updated to use Gymnasium, the maintained fork of OpenAI Gy
 
 ### Quick Setup (Ubuntu/Debian)
 
-Run the setup script which will install Python 3.11 if needed:
+Run the setup script which will install Python 3.12 if needed:
 
 ```bash
 bash scripts/setup.sh
@@ -27,10 +27,10 @@ bash scripts/setup.sh
 
 ### Manual Installation
 
-1. Ensure you have Python 3.11 installed (3.9-3.12 are all supported)
+1. Ensure you have Python 3.12 installed (3.9-3.12 are all supported)
 2. Create a virtual environment:
    ```bash
-   python3.11 -m venv venv
+   python3.12 -m venv venv
    source venv/bin/activate
    ```
 3. Install dependencies:

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ You can move left or right by selecting a discrete action. Reaching the rightmos
 
 ## Requirements
 
-- **Python 3.8-3.11** (tested with 3.8, 3.9, 3.10, 3.11)
+- **Python 3.9-3.12** (tested with 3.9, 3.10, 3.11, 3.12)
 - **Gymnasium 1.0.0** (modern fork of OpenAI Gym)
-- **NumPy 1.22.0** (minimum version to address security vulnerabilities)
+- **NumPy 1.26.0** (minimum version for Python 3.12 support)
 - **pytest 7.4.4** (for running tests)
 
 This project has been updated to use Gymnasium, the maintained fork of OpenAI Gym. The pinned versions are specified in `requirements.txt`.
@@ -27,7 +27,7 @@ bash scripts/setup.sh
 
 ### Manual Installation
 
-1. Ensure you have Python 3.11 installed (3.8-3.11 are all supported)
+1. Ensure you have Python 3.11 installed (3.9-3.12 are all supported)
 2. Create a virtual environment:
    ```bash
    python3.11 -m venv venv

--- a/gym_random_walk/_version.py
+++ b/gym_random_walk/_version.py
@@ -3,8 +3,8 @@
 __version__ = '0.2.0'
 
 # Dependency versions
-PYTHON_VERSION = '3.11'
-NUMPY_VERSION = '1.26.0'
+PYTHON_VERSION = '3.12'  # Default/recommended version
+NUMPY_VERSION = '1.26.4'
 GYMNASIUM_VERSION = '1.0.0'
 PYTEST_VERSION = '7.4.4'
 

--- a/gym_random_walk/_version.py
+++ b/gym_random_walk/_version.py
@@ -4,9 +4,9 @@ __version__ = '0.2.0'
 
 # Dependency versions
 PYTHON_VERSION = '3.11'
-NUMPY_VERSION = '1.22.0'
+NUMPY_VERSION = '1.26.0'
 GYMNASIUM_VERSION = '1.0.0'
 PYTEST_VERSION = '7.4.4'
 
 # Version requirements for setup.py
-PYTHON_REQUIRES = '>=3.8,<3.12'
+PYTHON_REQUIRES = '>=3.9,<3.14'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 gymnasium==1.0.0
 pytest==7.4.4
-numpy==1.26.0
+numpy==1.26.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 gymnasium==1.0.0
 pytest==7.4.4
-numpy==1.22.0
+numpy==1.26.0

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 # Navigate to the project root directory
 cd "$(dirname "$0")/.."
 
+# Python version configuration
+PYTHON_VERSION="3.12"
+PYTHON_VERSION_MAJOR_MINOR="${PYTHON_VERSION}"
+
 # Colors for output
 GREEN='\033[0;32m'
 RED='\033[0;31m'
@@ -27,74 +31,74 @@ else
     IS_DEBIAN_BASED=false
 fi
 
-# Check for Python 3.11
-echo "Checking for Python 3.11..."
-if command_exists python3.11; then
-    PYTHON_CMD=python3.11
-    echo -e "${GREEN}Found Python 3.11${NC}"
+# Check for Python ${PYTHON_VERSION}
+echo "Checking for Python ${PYTHON_VERSION}..."
+if command_exists python${PYTHON_VERSION}; then
+    PYTHON_CMD=python${PYTHON_VERSION}
+    echo -e "${GREEN}Found Python ${PYTHON_VERSION}${NC}"
 elif command_exists python3; then
-    # Check if it's 3.11.x
-    PYTHON_VERSION=$(python3 --version 2>&1 | awk '{print $2}')
-    if [[ $PYTHON_VERSION == 3.11.* ]]; then
+    # Check if it's the right version
+    DETECTED_VERSION=$(python3 --version 2>&1 | awk '{print $2}')
+    if [[ $DETECTED_VERSION == ${PYTHON_VERSION}.* ]]; then
         PYTHON_CMD=python3
-        echo -e "${GREEN}Found Python $PYTHON_VERSION${NC}"
+        echo -e "${GREEN}Found Python $DETECTED_VERSION${NC}"
     else
-        echo -e "${YELLOW}Python 3 found but version is $PYTHON_VERSION${NC}"
-        echo -e "${YELLOW}This project recommends Python 3.11${NC}"
+        echo -e "${YELLOW}Python 3 found but version is $DETECTED_VERSION${NC}"
+        echo -e "${YELLOW}This project recommends Python ${PYTHON_VERSION}${NC}"
         
         if [ "$IS_DEBIAN_BASED" = true ]; then
-            echo "Installing Python 3.11..."
+            echo "Installing Python ${PYTHON_VERSION}..."
             sudo apt-get update
             # Add deadsnakes PPA for Python versions
             sudo apt-get install -y software-properties-common
             sudo add-apt-repository -y ppa:deadsnakes/ppa
             sudo apt-get update
-            sudo apt-get install -y python3.11 python3.11-venv python3.11-dev
-            PYTHON_CMD=python3.11
+            sudo apt-get install -y python${PYTHON_VERSION} python${PYTHON_VERSION}-venv python${PYTHON_VERSION}-dev
+            PYTHON_CMD=python${PYTHON_VERSION}
         else
-            echo -e "${RED}Please install Python 3.11 manually and run this script again.${NC}"
-            echo -e "${RED}This project recommends Python 3.11${NC}"
+            echo -e "${RED}Please install Python ${PYTHON_VERSION} manually and run this script again.${NC}"
+            echo -e "${RED}This project recommends Python ${PYTHON_VERSION}${NC}"
             exit 1
         fi
     fi
 else
-    echo "Python 3.11 is not installed."
+    echo "Python ${PYTHON_VERSION} is not installed."
     if [ "$IS_DEBIAN_BASED" = true ]; then
-        echo "Installing Python 3.11..."
+        echo "Installing Python ${PYTHON_VERSION}..."
         sudo apt-get update
         sudo apt-get install -y software-properties-common
         sudo add-apt-repository -y ppa:deadsnakes/ppa
         sudo apt-get update
-        sudo apt-get install -y python3.11 python3.11-venv python3.11-dev
-        PYTHON_CMD=python3.11
+        sudo apt-get install -y python${PYTHON_VERSION} python${PYTHON_VERSION}-venv python${PYTHON_VERSION}-dev
+        PYTHON_CMD=python${PYTHON_VERSION}
     else
-        echo -e "${RED}Please install Python 3.11 manually and run this script again.${NC}"
+        echo -e "${RED}Please install Python ${PYTHON_VERSION} manually and run this script again.${NC}"
         exit 1
     fi
 fi
 
-# Check for pip for Python 3.11
+# Check for pip for Python ${PYTHON_VERSION}
 if ! $PYTHON_CMD -m pip --version >/dev/null 2>&1; then
-    echo "pip for Python 3.11 is not installed."
+    echo "pip for Python ${PYTHON_VERSION} is not installed."
     if [ "$IS_DEBIAN_BASED" = true ]; then
-        echo "Installing pip for Python 3.11..."
+        echo "Installing pip for Python ${PYTHON_VERSION}..."
         curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
         sudo $PYTHON_CMD get-pip.py
         rm get-pip.py
     else
-        echo -e "${RED}Please install pip for Python 3.11 manually and run this script again.${NC}"
+        echo -e "${RED}Please install pip for Python ${PYTHON_VERSION} manually and run this script again.${NC}"
         exit 1
     fi
 fi
 
-# Remove existing venv if it exists (to ensure we use Python 3.11)
+# Remove existing venv if it exists (to ensure we use Python ${PYTHON_VERSION})
 if [ -d "venv" ]; then
-    echo -e "${YELLOW}Removing existing virtual environment to recreate with Python 3.11...${NC}"
+    echo -e "${YELLOW}Removing existing virtual environment to recreate with Python ${PYTHON_VERSION}...${NC}"
     rm -rf venv
 fi
 
-# Create virtual environment with Python 3.11
-echo "Creating virtual environment with Python 3.11..."
+# Create virtual environment with Python ${PYTHON_VERSION}
+echo "Creating virtual environment with Python ${PYTHON_VERSION}..."
 $PYTHON_CMD -m venv venv
 
 # Activate virtual environment


### PR DESCRIPTION
## Summary
- Update Python 3.12 as the recommended/default version (while maintaining 3.9-3.13 compatibility)
- Update numpy from 1.26.0 to 1.26.4 for better Python 3.12 support
- Refactor setup.sh script to use PYTHON_VERSION variable, eliminating code duplication

## Changes
- Updated `_version.py` to set Python 3.12 as default
- Modified `setup.sh` to use a `PYTHON_VERSION` variable throughout
- Updated `requirements.txt` via the update script
- Updated documentation (README.md and CLAUDE.md) to show Python 3.12 as recommended

## Test plan
- [ ] Verify setup.sh script works on Ubuntu/Debian systems
- [ ] Confirm tests pass on all supported Python versions (3.9-3.12)
- [ ] Check that virtual environment is created with Python 3.12

🤖 Generated with [Claude Code](https://claude.ai/code)