### PR TITLE
Fix potential unbound variable and ruff linting issues

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -14,6 +14,9 @@ RED='\033[0;31m'
 YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
+# Initialize OS detection variable (required for set -u)
+IS_DEBIAN_BASED=false
+
 # Function to check if a command exists
 command_exists() {
     command -v "$1" >/dev/null 2>&1

--- a/scripts/update_requirements.py
+++ b/scripts/update_requirements.py
@@ -6,7 +6,8 @@ import os
 
 # Add gym_random_walk directory to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'gym_random_walk'))
-from _version import GYMNASIUM_VERSION, PYTEST_VERSION, NUMPY_VERSION, MATPLOTLIB_VERSION, RUFF_VERSION
+
+from _version import GYMNASIUM_VERSION, PYTEST_VERSION, NUMPY_VERSION, MATPLOTLIB_VERSION, RUFF_VERSION  # noqa: E402
 
 # Generate requirements.txt content
 requirements = f"""gymnasium=={GYMNASIUM_VERSION}

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ import sys
 
 # Add the package directory to sys.path so we can import _version
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'gym_random_walk'))
-from _version import __version__, PYTHON_REQUIRES, GYMNASIUM_VERSION, NUMPY_VERSION
+
+from _version import __version__, PYTHON_REQUIRES, GYMNASIUM_VERSION, NUMPY_VERSION  # noqa: E402
 
 setup(name='gym_random_walk',
       version=__version__,

--- a/tests/test_q_learning_example.py
+++ b/tests/test_q_learning_example.py
@@ -8,12 +8,12 @@ import numpy as np
 import subprocess
 import sys
 import os
+import gymnasium as gym
 
 # Add parent directory to path to import the example
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'examples'))
 
-from q_learning_agent import train_q_learning, epsilon_greedy_action, print_policy
-import gymnasium as gym
+from q_learning_agent import train_q_learning, epsilon_greedy_action, print_policy  # noqa: E402
 
 
 def test_epsilon_greedy_action():


### PR DESCRIPTION
## Summary
Fixes potential script failure under `set -u` and resolves ruff linting errors.

## Changes
- Initialize `IS_DEBIAN_BASED=false` at the top of setup.sh to prevent unbound variable errors
- Add `noqa: E402` comments to Python files that need sys.path manipulation before imports
- This makes the setup script more robust and ensures clean linting

## Test Plan
- [x] Run `bash scripts/setup.sh` - script executes without errors
- [x] Run `bash scripts/run.sh` - all tests pass and no linting errors

## Related Issues
Fixes #41

🤖 Generated with [Claude Code](https://claude.ai/code)